### PR TITLE
feat: normalizing paths to fix windows issues

### DIFF
--- a/example-express/debug.ps1
+++ b/example-express/debug.ps1
@@ -8,4 +8,4 @@ node ./snapshot/install-snapshot.js
 
 $env:DEBUG='(pack|snap)*(info|debug|error)*'
 $env:PROJECT_BASE_DIR=Get-Location
-.\node_modules\electron\dist\electron.exe -r ./app/hook-require.js ./app/index.js
+.\node_modules\electron\dist\electron.exe --inspect-brk -r ./app/hook-require.js ./app/index.js

--- a/example-express/run.ps1
+++ b/example-express/run.ps1
@@ -1,0 +1,10 @@
+$path = $MyInvocation.MyCommand.Path
+if ($path)  {$path = Split-Path $path -Parent}
+Set-Location $path
+
+$env:SNAPSHOT_BUNDLER='C:\Users\User\dev\v8-snapshot\esbuild\snapshot.exe'
+$env:SNAPSHOT_KEEP_CONFIG=1
+$env:DEBUG='(pack|snap)*(info|debug|error)*'
+
+node ./snapshot/install-snapshot.js
+.\node_modules\electron\dist\electron.exe -r ./app/hook-require.js ./app/index.js

--- a/example-express/run.ps1
+++ b/example-express/run.ps1
@@ -2,9 +2,10 @@ $path = $MyInvocation.MyCommand.Path
 if ($path)  {$path = Split-Path $path -Parent}
 Set-Location $path
 
-$env:SNAPSHOT_BUNDLER='C:\Users\User\dev\v8-snapshot\esbuild\snapshot.exe'
+$env:SNAPSHOT_BUNDLER='C:\Users\User\dev\esbuild\snapshot.exe'
 $env:SNAPSHOT_KEEP_CONFIG=1
-$env:DEBUG='(pack|snap)*(info|debug|error)*'
-
 node ./snapshot/install-snapshot.js
+
+$env:DEBUG='(pack|snap)*(info|debug|error)*'
+$env:PROJECT_BASE_DIR=Get-Location
 .\node_modules\electron\dist\electron.exe -r ./app/hook-require.js ./app/index.js

--- a/example-minimal/debug.ps1
+++ b/example-minimal/debug.ps1
@@ -8,4 +8,4 @@ node ./snapshot/install-snapshot.js
 
 $env:DEBUG='(pack|snap)*(info|debug|error)*'
 $env:PROJECT_BASE_DIR=Get-Location
-.\node_modules\electron\dist\electron.exe -r ./app/hook-require.js ./app/index.js
+.\node_modules\electron\dist\electron.exe --inspect-brk -r ./app/hook-require.js ./app/index.js

--- a/example-minimal/run.ps1
+++ b/example-minimal/run.ps1
@@ -1,0 +1,23 @@
+$path = $MyInvocation.MyCommand.Path
+if ($path)  {$path = Split-Path $path -Parent}
+Set-Location $path
+
+$env:SNAPSHOT_BUNDLER='C:\Users\User\dev\v8-snapshot\esbuild\snapshot.exe'
+$env:SNAPSHOT_KEEP_CONFIG=1
+node ./snapshot/install-snapshot.js
+
+$env:DEBUG='(pack|snap)*(info|debug|error)*'
+$env:PROJECT_BASE_DIR=Get-Location
+.\node_modules\electron\dist\electron.exe -r ./app/hook-require.js ./app/index.js
+
+
+
+//
+// Set env
+//
+$env:ELECTRON_RUN_AS_NODE=1
+
+//
+// Clean env
+//
+Remove-Item env:ELECTRON_RUN_AS_NODE

--- a/src/blueprint.ts
+++ b/src/blueprint.ts
@@ -4,6 +4,7 @@ import { BUNDLE_WRAPPER_OPEN } from './create-snapshot-script'
 import { inlineSourceMapComment } from './sourcemap/inline-sourcemap'
 import { processSourceMap } from './sourcemap/process-sourcemap'
 import debug from 'debug'
+import { forwardSlash } from './utils'
 
 const logDebug = debug('snapgen:debug')
 
@@ -49,6 +50,8 @@ export function scriptFromBlueprint(config: BlueprintConfig) {
     sourcemapEmbed,
     sourcemapExternalPath,
   } = config
+
+  const normalizedMainModuleRequirePath = forwardSlash(mainModuleRequirePath)
 
   const wrapperOpen = Buffer.from(
     `
@@ -114,7 +117,7 @@ function generateSnapshot() {
   ${customRequire}
   ${includeStrictVerifiers ? 'require.isStrict = true' : ''}
 
-  customRequire(${mainModuleRequirePath}, ${mainModuleRequirePath})
+  customRequire(${normalizedMainModuleRequirePath}, ${normalizedMainModuleRequirePath})
   return {
     customRequire,
     setGlobals: ${setGlobals},

--- a/src/blueprint/custom-require.js
+++ b/src/blueprint/custom-require.js
@@ -26,19 +26,6 @@ function customRequire(
   // The relative path to the module is used to resolve modules from the various caches
   let key = modulePathFromAppRoot
 
-  // Normalize path and key on Windows
-  if (PATH_SEP !== '/') {
-    modulePath = modulePath.startsWith('./')
-      ? `./${modulePath.slice(2).replace(/\//g, '\\')}`
-      : modulePath.replace(/\//g, '\\')
-
-    if (key != null) {
-      key = key.startsWith('./')
-        ? `./${key.slice(2).replace(/\//g, '\\')}`
-        : key.replace(/\//g, '\\')
-    }
-  }
-
   // This is a somewhat brittle attempt to resolve the parent if it is the receiver
   const loader /* NodeModule? */ =
     this != null && this !== global && this.id != null && this.filename != null

--- a/src/loading/snapshot-require.ts
+++ b/src/loading/snapshot-require.ts
@@ -8,6 +8,7 @@ import type {
 import { packherdRequire } from 'packherd/dist/src/require.js'
 import { Snapshot, SnapshotAuxiliaryData } from '../types'
 import { EMBEDDED } from '../constants'
+import { forwardSlash } from '../utils'
 import Module from 'module'
 import { DependencyMap, DependencyMapArray } from '../meta/dependency-map'
 
@@ -33,7 +34,9 @@ function createGetModuleKey(resolverMap?: Record<string, string>) {
     }
 
     // Use posix version of the path module to keep forward slashes going
-    const relParentDir = opts.relPath ?? path.posix.relative(baseDir, opts.path)
+    const relParentDir = forwardSlash(
+      opts.relPath ?? path.relative(baseDir, opts.path)
+    )
     const resolverKey = `${relParentDir}${RESOLVER_MAP_KEY_SEP}${moduleUri}`
 
     const resolved = resolverMap[resolverKey]

--- a/src/meta/dependency-map.ts
+++ b/src/meta/dependency-map.ts
@@ -69,6 +69,8 @@ function dependencyArrayToResolvedMap(
   arr: DependencyMapArray,
   projectBaseDir: string
 ) {
+  // NOTE: using path.resolve here guarantess that map keys/values are native slashed
+  // even though the included dependency map array uses always forward slashes
   const map: Map<string, DependencyNode> = new Map()
   for (const [k, { directDeps, allDeps }] of arr) {
     const resolvedKey = path.resolve(projectBaseDir, k)

--- a/src/tests/doctor/deep-nested-deferred.ts
+++ b/src/tests/doctor/deep-nested-deferred.ts
@@ -3,6 +3,7 @@ import test from 'tape'
 import { SnapshotGenerator } from '../../snapshot-generator'
 import { exec as execOrig } from 'child_process'
 import { promisify } from 'util'
+import { electronExecutable } from '../utils/consts'
 
 import rimraf from 'rimraf'
 const rmrf = promisify(rimraf)
@@ -24,13 +25,12 @@ test('doctor: entry requires a module that depends on a module needing to be def
 
   const env: Record<string, any> = {
     ELECTRON_RUN_AS_NODE: 1,
-    DEBUG: '(packherd|snapgen):*',
+    DEBUG: process.env.DEBUG ?? '(packherd|snapgen):*',
     PROJECT_BASE_DIR: projectBaseDir,
     DEBUG_COLORS: 1,
   }
   const cmd =
-    `node ${require.resolve('electron/cli')}` +
-    ` -r ${projectBaseDir}/hook-require.js` +
+    `${electronExecutable} -r ${projectBaseDir}/hook-require.js` +
     ` ${projectBaseDir}/app.js`
 
   let stdout: string | undefined
@@ -38,7 +38,7 @@ test('doctor: entry requires a module that depends on a module needing to be def
   try {
     ;({ stdout, stderr } = await exec(cmd, { env }))
     const res = JSON.parse(stdout.trim())
-    console.log(res)
+    console.log(stderr)
     t.equal(res.errname, 'Unknown system error -666')
   } catch (err: any) {
     console.log(stdout)

--- a/src/tests/doctor/fixtures/deep-nested-deferred/commit-info/node_modules/execa/index.js
+++ b/src/tests/doctor/fixtures/deep-nested-deferred/commit-info/node_modules/execa/index.js
@@ -1,0 +1,7 @@
+// Reproduces execa code using lib errname which needs to be deferred
+
+const errname = require('./lib/errname')
+
+module.exports = function getErrname(n) {
+  return errname(n)
+}

--- a/src/tests/doctor/fixtures/deep-nested-deferred/commit-info/node_modules/execa/lib/errname.js
+++ b/src/tests/doctor/fixtures/deep-nested-deferred/commit-info/node_modules/execa/lib/errname.js
@@ -1,0 +1,10 @@
+// Reproduces code that causes this module to be deferred
+
+const util = require('util')
+
+// Added in: v9.7.0 so for our test case this we don't need to consider the else branch
+if (typeof util.getSystemErrorName === 'function') {
+  module.exports = util.getSystemErrorName
+} else {
+  module.exports = () => 'Used to be uv.errname'
+}

--- a/src/tests/doctor/no-rewrite.test.ts
+++ b/src/tests/doctor/no-rewrite.test.ts
@@ -3,6 +3,7 @@ import test from 'tape'
 import { SnapshotGenerator } from '../../snapshot-generator'
 import { exec as execOrig } from 'child_process'
 import { promisify } from 'util'
+import { electronExecutable } from '../utils/consts'
 
 import rimraf from 'rimraf'
 const rmrf = promisify(rimraf)
@@ -29,8 +30,7 @@ test('doctor: entry requires a module that has is detected norewrite', async (t)
     DEBUG_COLORS: 1,
   }
   const cmd =
-    `node ${require.resolve('electron/cli')}` +
-    ` -r ${projectBaseDir}/hook-require.js` +
+    `${electronExecutable} -r ${projectBaseDir}/hook-require.js` +
     ` ${projectBaseDir}/app.js`
 
   let stdout: string | undefined

--- a/src/tests/esbuild/rewrites.test.ts
+++ b/src/tests/esbuild/rewrites.test.ts
@@ -4,6 +4,7 @@ import test from 'tape'
 import { SnapshotGenerator } from '../../snapshot-generator'
 import { exec as execOrig } from 'child_process'
 import { promisify } from 'util'
+import { electronExecutable } from '../utils/consts'
 
 const exec = promisify(execOrig)
 
@@ -26,8 +27,7 @@ test('esbuild: rewriting mutli assignments and multi exports', async (t) => {
     DEBUG_COLORS: 1,
   }
   const cmd =
-    `node ${require.resolve('electron/cli')}` +
-    ` -r ${projectBaseDir}/hook-require.js` +
+    `${electronExecutable} -r ${projectBaseDir}/hook-require.js` +
     ` ${projectBaseDir}/app.js`
 
   try {

--- a/src/tests/esbuild/windows-issues.test.ts
+++ b/src/tests/esbuild/windows-issues.test.ts
@@ -3,6 +3,7 @@ import test from 'tape'
 import { SnapshotGenerator } from '../../snapshot-generator'
 import { exec as execOrig } from 'child_process'
 import { promisify } from 'util'
+import { electronExecutable } from '../utils/consts'
 
 const exec = promisify(execOrig)
 
@@ -25,8 +26,7 @@ test('esbuild: windows-issues', async (t) => {
     DEBUG_COLORS: 1,
   }
   const cmd =
-    `node ${require.resolve('electron/cli')}` +
-    ` -r ${projectBaseDir}/hook-require.js` +
+    `${electronExecutable} -r ${projectBaseDir}/hook-require.js` +
     ` ${projectBaseDir}/app.js`
 
   let stdout, stderr

--- a/src/tests/integration/express.test.ts
+++ b/src/tests/integration/express.test.ts
@@ -22,9 +22,10 @@ test('integration: install snapshot for example-express', async (t) => {
     return t.end()
   }
 
+  const _MB = 1024 * 1024
   const cmd = `node ./snapshot/install-snapshot.js`
   try {
-    await exec(cmd, { cwd: projectBaseDir })
+    await exec(cmd, { cwd: projectBaseDir, maxBuffer: 600 * _MB })
     const metadata = require(metadataFile)
     spok(t, metadata, EXPECTED)
     t.end()

--- a/src/tests/loading/deferred-from-healthy.test.ts
+++ b/src/tests/loading/deferred-from-healthy.test.ts
@@ -4,6 +4,7 @@ import test from 'tape'
 import { SnapshotGenerator } from '../../snapshot-generator'
 import { exec as execOrig } from 'child_process'
 import { promisify } from 'util'
+import { electronExecutable } from '../utils/consts'
 
 const exec = promisify(execOrig)
 
@@ -26,8 +27,7 @@ test('negotiator: healthy module requires a deferred one', async (t) => {
     DEBUG_COLORS: 1,
   }
   const cmd =
-    `node ${require.resolve('electron/cli')}` +
-    ` -r ${projectBaseDir}/hook-require.js` +
+    `${electronExecutable} -r ${projectBaseDir}/hook-require.js` +
     ` ${projectBaseDir}/app.js`
 
   try {

--- a/src/tests/loading/esm.test.ts
+++ b/src/tests/loading/esm.test.ts
@@ -4,6 +4,7 @@ import test from 'tape'
 import { SnapshotGenerator } from '../../snapshot-generator'
 import { exec as execOrig } from 'child_process'
 import { promisify } from 'util'
+import { electronExecutable } from '../utils/consts'
 
 const exec = promisify(execOrig)
 
@@ -26,8 +27,7 @@ test('esm support: entry esm module importing a lodash function', async (t) => {
     DEBUG_COLORS: 1,
   }
   const cmd =
-    `node ${require.resolve('electron/cli')}` +
-    ` -r ${projectBaseDir}/hook-require.js` +
+    `${electronExecutable} -r ${projectBaseDir}/hook-require.js` +
     ` ${projectBaseDir}/app.js`
 
   try {

--- a/src/tests/loading/external-from-healthy.test.ts
+++ b/src/tests/loading/external-from-healthy.test.ts
@@ -3,6 +3,7 @@ import test from 'tape'
 import { SnapshotGenerator } from '../../snapshot-generator'
 import { exec as execOrig } from 'child_process'
 import { promisify } from 'util'
+import { electronExecutable } from '../utils/consts'
 
 const exec = promisify(execOrig)
 
@@ -25,8 +26,7 @@ test('negotiator: healthy module requires an external one', async (t) => {
     DEBUG_COLORS: 1,
   }
   const cmd =
-    `node ${require.resolve('electron/cli')}` +
-    ` -r ${projectBaseDir}/hook-require.js` +
+    `${electronExecutable} -r ${projectBaseDir}/hook-require.js` +
     ` ${projectBaseDir}/app.js`
 
   try {

--- a/src/tests/loading/native-modules.test.ts
+++ b/src/tests/loading/native-modules.test.ts
@@ -4,6 +4,7 @@ import test from 'tape'
 import { SnapshotGenerator } from '../../snapshot-generator'
 import { exec as execOrig } from 'child_process'
 import { promisify } from 'util'
+import { electronExecutable } from '../utils/consts'
 
 if (process.platform == 'darwin') {
   const exec = promisify(execOrig)
@@ -27,8 +28,7 @@ if (process.platform == 'darwin') {
       DEBUG_COLORS: 1,
     }
     const cmd =
-      `node ${require.resolve('electron/cli')}` +
-      ` -r ${projectBaseDir}/hook-require.js` +
+      `${electronExecutable} -r ${projectBaseDir}/hook-require.js` +
       ` ${projectBaseDir}/app.js`
 
     try {

--- a/src/tests/loading/require-cache.test.ts
+++ b/src/tests/loading/require-cache.test.ts
@@ -3,6 +3,7 @@ import test from 'tape'
 import { SnapshotGenerator } from '../../snapshot-generator'
 import { exec as execOrig } from 'child_process'
 import { promisify } from 'util'
+import { electronExecutable } from '../utils/consts'
 
 import rimraf from 'rimraf'
 const rmrf = promisify(rimraf)
@@ -30,8 +31,7 @@ test('require: cached module modifies require cache', async (t) => {
     DEBUG_COLORS: 1,
   }
   const cmd =
-    `node ${require.resolve('electron/cli')}` +
-    ` -r ${projectBaseDir}/hook-require.js` +
+    `${electronExecutable} -r ${projectBaseDir}/hook-require.js` +
     ` ${projectBaseDir}/cached-app.js`
 
   try {
@@ -62,7 +62,7 @@ test('require: uncached module modifies require cache', async (t) => {
     DEBUG_COLORS: 1,
   }
   const cmd =
-    `node ${require.resolve('electron/cli')}` +
+    `${electronExecutable} -r ${projectBaseDir}/hook-require.js` +
     ` -r ${projectBaseDir}/hook-require.js` +
     ` ${projectBaseDir}/uncached-app.js`
 

--- a/src/tests/loading/require-full-path-var.test.ts
+++ b/src/tests/loading/require-full-path-var.test.ts
@@ -3,6 +3,7 @@ import test from 'tape'
 import { SnapshotGenerator } from '../../snapshot-generator'
 import { exec as execOrig } from 'child_process'
 import { promisify } from 'util'
+import { electronExecutable } from '../utils/consts'
 
 const exec = promisify(execOrig)
 
@@ -25,8 +26,7 @@ test('require: loading from full path provided via variable', async (t) => {
     DEBUG_COLORS: 1,
   }
   const cmd =
-    `node ${require.resolve('electron/cli')}` +
-    ` -r ${projectBaseDir}/hook-require.js` +
+    `${electronExecutable} -r ${projectBaseDir}/hook-require.js` +
     ` ${projectBaseDir}/app.js`
 
   let stdout: string | undefined

--- a/src/tests/loading/stealthy-require.test.ts
+++ b/src/tests/loading/stealthy-require.test.ts
@@ -3,6 +3,7 @@ import test from 'tape'
 import { SnapshotGenerator } from '../../snapshot-generator'
 import { exec as execOrig } from 'child_process'
 import { promisify } from 'util'
+import { electronExecutable } from '../utils/consts'
 
 import rimraf from 'rimraf'
 const rmrf = promisify(rimraf)
@@ -29,8 +30,7 @@ test('stealthy-require: all cached ', async (t) => {
     DEBUG_COLORS: 1,
   }
   const cmd =
-    `node ${require.resolve('electron/cli')}` +
-    ` -r ${projectBaseDir}/hook-require.js` +
+    `${electronExecutable} -r ${projectBaseDir}/hook-require.js` +
     ` ${projectBaseDir}/spec/non-native.js`
 
   try {

--- a/src/tests/utils/consts.ts
+++ b/src/tests/utils/consts.ts
@@ -1,0 +1,3 @@
+const electronPath = require('electron/index.js')
+
+export const electronExecutable = electronPath

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -130,6 +130,11 @@ export function backupName(orig: string) {
   return `${file.slice(0, -extLen)}.orig${ext}`
 }
 
+export const forwardSlash =
+  path.sep === path.posix.sep
+    ? (p: string) => p
+    : (p: string) => p.replace(/(\\)+/g, '/')
+
 export function installedElectronResourcesFilePath(
   root: string,
   electronFile: string


### PR DESCRIPTION
Our esbuild fork now ouputs all paths in metadata as well has exports/definitions hashed in the
bundle with forward slashes.

See: https://github.com/cypress-io/esbuild/pull/9

This PR adapts the v8-snapshot code to this change.
